### PR TITLE
Added breakable URLs

### DIFF
--- a/lib/splitflap.js
+++ b/lib/splitflap.js
@@ -168,7 +168,8 @@ module.exports = function (lines, initialized) {
 			var j = 0;
 			for (var i = text.length-1; i >= 0; i--) {
 				var code = text.charCodeAt(i);
-				if ((code == 10) || (code == 32)) {
+				//Brakeable chars: 10 = Line Feed | 32 = Space |45 = - | 47 = / | 95 = _
+				if ((code == 10) || (code == 32) || (code == 45) || (code == 47) || (code == 95)) {
 					j = 0;
 				} else {
 					j++;
@@ -190,7 +191,11 @@ module.exports = function (lines, initialized) {
 					// force break
 					index = field.nextLine[index];
 				} else if ((code == 32) && (field.col[index] == 0)) {
-					//ignore spaces in the beginning
+					// ignore spaces in the beginning
+				} else if (((code == 45) || (code == 47) ||  (code == 95)) && (field.col[index] == 0)) {
+					// handle breaking URLs correctly, when starting with special char in new line
+					add(index, char);
+					index++;
 				} else if (field.row[wordLength[i]+index-1] != field.row[index]) {
 					// word break
 					if (field.row[index] == field.rowCount-1) {
@@ -204,7 +209,7 @@ module.exports = function (lines, initialized) {
 					add(index, char);
 					index++;
 				} else {
-						add(index, char);
+					add(index, char);
 					index++;
 				}
 			}


### PR DESCRIPTION
Lange Zeichenketten werden nicht richtig umgebrochen. Möchte man beispielsweise eine URL darstellen wird diese nicht angezeigt, sondern nur die ersten Buchtstaben in jeder Zeile. Dies wurde geändert, in dem Wörter nicht nur bei Leerzeichen sondern auch bei "/", "-" und "_" umgebrochen werden. 
Weitere Buchstaben können mit dem gleichen Vorgehen über den ASCII-Code hinzugefügt werden.